### PR TITLE
Feature/tlva 216/orders link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+ - update link of tfg-order of my account of the order-confirmation page
 
 ## [1.9.0] - 2022-03-29
 

--- a/react/OrderOptions.tsx
+++ b/react/OrderOptions.tsx
@@ -61,7 +61,7 @@ const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
           <ButtonLink
             variation="secondary"
             fullWidth={fullWidth}
-            to={`${myAccountPath}#/orders/${orderId}/edit`}>
+            to={`${myAccountPath}#/tfg-orders/${orderId}`}>
             {intl.formatMessage(messages.updateButton)}
           </ButtonLink>
         )}
@@ -74,7 +74,7 @@ const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
           <ButtonLink
             variation="secondary"
             fullWidth={fullWidth}
-            to={`${myAccountPath}#/orders/`}>
+            to={`${myAccountPath}#/tfg-orders/`}>
             {intl.formatMessage(messages.myOrdersButton)}
           </ButtonLink>
         </div>
@@ -89,7 +89,7 @@ const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
             <ButtonLink
               variation="danger-tertiary"
               fullWidth={fullWidth}
-              to={`${myAccountPath}#/orders/${orderId}/cancel`}>
+              to={`${myAccountPath}#/tfg-orders/${orderId}/cancel`}>
               {intl.formatMessage(messages.cancelButton)}
             </ButtonLink>
           )}


### PR DESCRIPTION
### What problem is this solving?
Update link de seccion order de mi cuenta de la pagina order-confirmation

#### How it works
https://www.loom.com/share/bc793b5f76c048fba0da52f398eef8b5

#### How to test it?
[workspace](https://tlva216--thefoschini.myvtex.com/)
https://www.loom.com/share/bc793b5f76c048fba0da52f398eef8b5

 - Place an order
 - on the order-confirmation page, click on the "Update Order" button.
 - The next page should be: https://tlva216--thefoschini.myvtex.com/account#/tfg-orders/{id-order}

You can also try my account

Credentials:
user: jesus.rodrigo@acct.global pass: Acct12345
URL: https://tlva216--thefoschini.myvtex.com/checkout/orderPlaced/?og=1234641301303

### Screenshots/Video example usage:
https://www.loom.com/share/bc793b5f76c048fba0da52f398eef8b5
